### PR TITLE
Update dependabot.yml to perform daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@
 
 version: 2
 updates:
-  # Update npm dependencies
-  - package-ecosystem: 'npm'
-    directory: '/' # Location of package.json
+  - package-ecosystem: 'npm' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    open-pull-requests-limit: 25
     schedule:
       interval: 'daily'
 
@@ -15,10 +15,11 @@ updates:
   # - package-ecosystem: 'github-actions'
   #   directory: '/' # Location of GitHub Actions workflows
   #   schedule:
-  #     interval: 'weekly'
+  #     interval: 'daily'
 
-  # Update Docker dependencies (if applicable)
-  - package-ecosystem: 'docker'
-    directory: '/' # Location of Dockerfile
-    schedule:
-      interval: 'daily'
+  # # Update Docker dependencies (if applicable)
+  # - package-ecosystem: 'docker'
+  #   directory: '/' # Location of Dockerfile
+  #   open-pull-requests-limit: 25
+  #   schedule:
+  #     interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,16 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/' # Location of package.json
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
 
-  # Update GitHub Actions
-  - package-ecosystem: 'github-actions'
-    directory: '/' # Location of GitHub Actions workflows
-    schedule:
-      interval: 'weekly'
+  # # Update GitHub Actions
+  # - package-ecosystem: 'github-actions'
+  #   directory: '/' # Location of GitHub Actions workflows
+  #   schedule:
+  #     interval: 'weekly'
 
   # Update Docker dependencies (if applicable)
   - package-ecosystem: 'docker'
     directory: '/' # Location of Dockerfile
     schedule:
-      interval: 'weekly'
+      interval: 'daily'


### PR DESCRIPTION
Removing the github actions updates because those require their own set of CI tests before we can have them auto merged into the development branch.